### PR TITLE
Kernel and Filter Bug Fixes

### DIFF
--- a/src/utils/filter.rs
+++ b/src/utils/filter.rs
@@ -79,11 +79,13 @@ where
     }
 
     pub fn receptive_field(&self, input: &Tensor<E>) -> Vec<Tensor<E>> {
+        let depth = input.shape()[0];
         let mut filters = vec![];
 
         let dilated_size = self.filter_size();
-        let size = dilated_size.insert_axis(Axis(0));
         let stride = self.stride.insert_axis(Axis(0));
+        let mut size = dilated_size.insert_axis(Axis(0));
+        size[0] = depth;
 
         for filter in input.windows_with_stride(size, stride) {
             let dilated_filter = self.dilate_filter(&filter.to_owned());

--- a/tests/filter.rs
+++ b/tests/filter.rs
@@ -22,6 +22,29 @@ fn valid_filter_output_size_for_input() {
 }
 
 #[test]
+fn valid_receptive_field() {
+    let (filter_size, stride, dilation) = ((2, 2), (1, 2), (1, 1));
+    let filter = Filter::new(filter_size, stride, dilation);
+
+    let input = tensor![
+        [[1., 2., 3., 4.], [5., 6., 7., 8.], [9., 10., 11., 12.]],
+        [
+            [13., 14., 15., 16.,],
+            [17., 18., 19., 20.,],
+            [21., 22., 23., 24.,]
+        ]
+    ];
+    let output: Vec<Tensor<Ix3>> = vec![
+        tensor![[[1., 2.], [5., 6.]], [[13., 14.], [17., 18.]]],
+        tensor![[[3., 4.], [7., 8.]], [[15., 16.], [19., 20.]]],
+        tensor![[[5., 6.], [9., 10.]], [[17., 18.], [21., 22.]]],
+        tensor![[[7., 8.], [11., 12.]], [[19., 20.], [23., 24.]]],
+    ];
+
+    assert_eq!(filter.receptive_field(&input), output);
+}
+
+#[test]
 fn valid_receptive_field_with_dilation() {
     let (filter_size, stride, dilation) = ((2, 2), (2, 1), (2, 2));
     let filter = Filter::new(filter_size, stride, dilation);


### PR DESCRIPTION
Fixes
- A kernel's bias was being added to every element within the receptive field, which is wrong, the proper approach is to add the bias after the convolution operation
-  The window size for a given input was not taking into account the depth of the input and was always defaulting to a depth of 1.

This PR fixes and includes tests for both of these bugs