### PR TITLE
Added Adam Optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Any type of contribution is welcome as long as it adds value! i.e
   - [~~Lecun~~](https://www.tensorflow.org/api_docs/python/tf/keras/initializers/LecunNormal)
 - [~~Create optimizer module for optimization algorithms~~](https://pytorch.org/docs/stable/optim.html)
   - [~~SGD~~](https://pytorch.org/docs/stable/generated/torch.optim.SGD.html#torch.optim.SGD)
-  - [Adam](https://pytorch.org/docs/stable/generated/torch.optim.Adam.html#torch.optim.Adam)
+  - [~~Adam~~](https://pytorch.org/docs/stable/generated/torch.optim.Adam.html#torch.optim.Adam)
   - [~~RMSProp~~](https://pytorch.org/docs/stable/generated/torch.optim.RMSprop.html#torch.optim.RMSprop)
 - Convolutional Neural Networks
   - [~~Convolutional Layer~~](https://pytorch.org/docs/stable/generated/torch.nn.Conv2d.html)

--- a/src/optimizers/adam.rs
+++ b/src/optimizers/adam.rs
@@ -1,0 +1,99 @@
+use num_traits::Pow;
+
+use super::Optimizer;
+use crate::prelude::*;
+
+#[derive(Default)]
+pub struct AdamCache {
+    pub time_step: usize,
+    pub exp_avgs: Option<Array1<f64>>,
+    pub exp_avg_sqs: Option<Array1<f64>>,
+    pub max_exp_avg_sqs: Option<Array1<f64>>,
+}
+
+pub struct Adam {
+    pub params: Vec<Value>,
+    pub lr: Value,
+    pub betas: (f64, f64),
+    pub eps: f64,
+    pub weight_decay: f64,
+    pub amsgrad: bool,
+    pub maximize: bool,
+    pub cache: AdamCache,
+}
+
+impl Default for Adam {
+    fn default() -> Self {
+        Adam {
+            params: vec![],
+            lr: val!(0.001),
+            betas: (0.9, 0.999),
+            eps: 1e-8,
+            weight_decay: 0.0,
+            amsgrad: false,
+            maximize: false,
+            cache: Default::default(),
+        }
+    }
+}
+
+impl Optimizer for Adam {
+    fn step(&mut self) {
+        let params_n = self.params.len();
+        let (beta1, beta2) = self.betas;
+        let AdamCache {
+            ref mut time_step,
+            ref mut exp_avgs,
+            ref mut exp_avg_sqs,
+            ref mut max_exp_avg_sqs,
+        } = self.cache;
+
+        let exp_avgs = exp_avgs.get_or_insert(Array1::from_vec(vec![0.; params_n]));
+        let exp_avg_sqs = exp_avg_sqs.get_or_insert(Array1::from_vec(vec![0.; params_n]));
+        let max_exp_avg_sqs = max_exp_avg_sqs.get_or_insert(Array1::from_vec(vec![0.; params_n]));
+
+        for (i, param) in self.params.iter().enumerate() {
+            let mut grad = param
+                .grad()
+                .unwrap_or_else(|| panic!("Optimizer cannot step when gradient is None."))
+                .value();
+
+            if self.maximize {
+                grad = -grad;
+            }
+            grad += param.value() * self.weight_decay;
+
+            exp_avgs[i] = (beta1 * exp_avgs[i]) + ((1. - beta1) * grad);
+            exp_avg_sqs[i] = (beta2 * exp_avg_sqs[i]) + ((1. - beta2) * grad.pow(2));
+
+            let t = 1 + (*time_step as i32);
+            let bias_correction1 = 1. - beta1.powi(t);
+            let bias_correction2 = 1. - beta2.powi(t);
+
+            let step_size = self.lr.value() / bias_correction1;
+
+            let bias_correction2_sqrt = bias_correction2.sqrt();
+
+            let denom = if self.amsgrad {
+                max_exp_avg_sqs[i] = max_exp_avg_sqs[i].max(exp_avg_sqs[i]);
+                (max_exp_avg_sqs[i].sqrt() / bias_correction2_sqrt) + self.eps
+            } else {
+                (exp_avg_sqs[i].sqrt() / bias_correction2_sqrt) + self.eps
+            };
+            let step = (exp_avgs[i] / denom) * step_size;
+
+            *param.value_mut() -= step;
+        }
+        *time_step += 1;
+    }
+
+    fn zero_grad(&mut self) {
+        for param in self.params.iter() {
+            param.zero_grad();
+        }
+    }
+
+    fn lr(&self) -> Value {
+        self.lr.clone()
+    }
+}

--- a/src/optimizers/adam.rs
+++ b/src/optimizers/adam.rs
@@ -1,5 +1,3 @@
-use num_traits::Pow;
-
 use super::Optimizer;
 use crate::prelude::*;
 
@@ -64,11 +62,11 @@ impl Optimizer for Adam {
             grad += param.value() * self.weight_decay;
 
             exp_avgs[i] = (beta1 * exp_avgs[i]) + ((1. - beta1) * grad);
-            exp_avg_sqs[i] = (beta2 * exp_avg_sqs[i]) + ((1. - beta2) * grad.pow(2));
+            exp_avg_sqs[i] = (beta2 * exp_avg_sqs[i]) + ((1. - beta2) * grad.powf(2.0));
 
             let t = 1 + (*time_step as i32);
-            let bias_correction1 = 1. - beta1.powi(t);
-            let bias_correction2 = 1. - beta2.powi(t);
+            let bias_correction1 = 1.0 - beta1.powi(t);
+            let bias_correction2 = 1.0 - beta2.powi(t);
 
             let step_size = self.lr.value() / bias_correction1;
 

--- a/src/optimizers/mod.rs
+++ b/src/optimizers/mod.rs
@@ -1,6 +1,8 @@
+mod adam;
 mod rmsprop;
 mod sgd;
 
+pub use self::adam::Adam;
 pub use self::rmsprop::RMSProp;
 pub use self::sgd::SGD;
 pub use crate::value::Value;

--- a/src/optimizers/rmsprop.rs
+++ b/src/optimizers/rmsprop.rs
@@ -1,5 +1,3 @@
-use num_traits::Pow;
-
 use super::Optimizer;
 use crate::prelude::*;
 
@@ -58,12 +56,12 @@ impl Optimizer for RMSProp {
                 .value();
             grad += param.value() * self.weight_decay;
 
-            moving_avg[i] = (self.alpha * moving_avg[i]) + ((1. - self.alpha) * grad.pow(2));
+            moving_avg[i] = (self.alpha * moving_avg[i]) + ((1. - self.alpha) * grad.powf(2.0));
             let mut curr_moving_avg = moving_avg[i];
 
             if self.centered {
                 avg_gradients[i] = (self.alpha * avg_gradients[i]) + ((1. - self.alpha) * grad);
-                curr_moving_avg -= avg_gradients[i].pow(2);
+                curr_moving_avg -= avg_gradients[i].powf(2.0);
             }
 
             let momentum = self.momentum * prev_grads[i];

--- a/tests/optimizers/adam.rs
+++ b/tests/optimizers/adam.rs
@@ -1,0 +1,206 @@
+extern crate micrograd_rs;
+use approx::assert_abs_diff_eq;
+use micrograd_rs::optim::{Adam, Optimizer};
+use micrograd_rs::prelude::*;
+
+const VALUES: [f64; 5] = [1., 1., 1., 1., 1.];
+const STARTING_GRADS: [f64; 5] = [1., 1., 1., 1., 1.];
+
+fn build_params() -> Vec<Value> {
+    VALUES
+        .into_iter()
+        .zip(STARTING_GRADS)
+        .map(|(val, grad)| {
+            let value = Value::from(val);
+            *value.grad_mut() = Value::from(grad);
+            value
+        })
+        .collect()
+}
+
+fn set_grads(values: &Vec<Value>, grad: f64) {
+    for value in values.iter() {
+        *value.grad_mut() = val!(grad);
+    }
+}
+
+fn assert_params(params: &Vec<Value>, actuals: Vec<f64>) {
+    for (param, actual) in params.iter().zip(actuals) {
+        assert_abs_diff_eq!(param.value(), actual, epsilon = 1e-6);
+    }
+}
+
+#[test]
+fn valid_adam_learning_rate_update() {
+    let params = build_params();
+
+    let mut optim = Adam {
+        params: params.clone(),
+        lr: val!(0.05),
+        ..Default::default()
+    };
+
+    optim.step();
+    let first_step = vec![0.95; 5];
+    assert_params(&params, first_step);
+
+    set_grads(&params, -2.0);
+
+    optim.step();
+    let second_step = vec![0.9683052; 5];
+    assert_params(&params, second_step);
+}
+
+#[test]
+fn valid_adam_learning_rate_without_first_moment_decay_update() {
+    let params = build_params();
+
+    let mut optim = Adam {
+        params: params.clone(),
+        lr: val!(0.05),
+        betas: (0.0, 0.999),
+        ..Default::default()
+    };
+
+    optim.step();
+    let first_step = vec![0.95; 5];
+    assert_params(&params, first_step);
+
+    set_grads(&params, -2.0);
+
+    optim.step();
+    let second_step = vec![1.013236; 5];
+    assert_params(&params, second_step);
+}
+
+#[test]
+fn valid_adam_learning_rate_without_second_moment_decay_update() {
+    let params = build_params();
+
+    let mut optim = Adam {
+        params: params.clone(),
+        lr: val!(0.05),
+        betas: (0.9, 0.0),
+        ..Default::default()
+    };
+
+    optim.step();
+    let first_step = vec![0.95; 5];
+    assert_params(&params, first_step);
+
+    set_grads(&params, -2.0);
+
+    optim.step();
+    let second_step = vec![0.9644737; 5];
+    assert_params(&params, second_step);
+}
+
+#[test]
+fn valid_adam_learning_rate_without_moment_decay_update() {
+    let params = build_params();
+
+    let mut optim = Adam {
+        params: params.clone(),
+        lr: val!(0.05),
+        betas: (0.0, 0.0),
+        ..Default::default()
+    };
+
+    optim.step();
+    let first_step = vec![0.95; 5];
+    assert_params(&params, first_step);
+
+    set_grads(&params, -2.0);
+
+    optim.step();
+    let second_step = vec![1.0; 5];
+    assert_params(&params, second_step);
+}
+
+#[test]
+fn valid_adam_learning_rate_with_eps_update() {
+    let params = build_params();
+
+    let mut optim = Adam {
+        params: params.clone(),
+        lr: val!(0.05),
+        eps: 1e-4,
+        ..Default::default()
+    };
+
+    optim.step();
+    let first_step = vec![0.950005; 5];
+    assert_params(&params, first_step);
+
+    set_grads(&params, -2.0);
+
+    optim.step();
+    let second_step = vec![0.968309; 5];
+    assert_params(&params, second_step);
+}
+
+#[test]
+fn valid_adam_learning_rate_with_weight_decay_update() {
+    let params = build_params();
+
+    let mut optim = Adam {
+        params: params.clone(),
+        lr: val!(0.05),
+        weight_decay: 2.0,
+        ..Default::default()
+    };
+
+    optim.step();
+    let first_step = vec![0.95; 5];
+    assert_params(&params, first_step);
+
+    set_grads(&params, -2.0);
+
+    optim.step();
+    let second_step = vec![0.9177558; 5];
+    assert_params(&params, second_step);
+}
+
+#[test]
+fn valid_adam_learning_rate_with_amsgrad_update() {
+    let params = build_params();
+
+    let mut optim = Adam {
+        params: params.clone(),
+        lr: val!(0.05),
+        amsgrad: true,
+        ..Default::default()
+    };
+
+    optim.step();
+    let first_step = vec![0.95; 5];
+    assert_params(&params, first_step);
+
+    set_grads(&params, -2.0);
+
+    optim.step();
+    let second_step = vec![0.9683052; 5];
+    assert_params(&params, second_step);
+}
+
+#[test]
+fn valid_adam_learning_rate_with_maximize_update() {
+    let params = build_params();
+
+    let mut optim = Adam {
+        params: params.clone(),
+        lr: val!(0.05),
+        maximize: true,
+        ..Default::default()
+    };
+
+    optim.step();
+    let first_step = vec![1.05; 5];
+    assert_params(&params, first_step);
+
+    set_grads(&params, -2.0);
+
+    optim.step();
+    let second_step = vec![1.0316948; 5];
+    assert_params(&params, second_step);
+}

--- a/tests/optimizers/mod.rs
+++ b/tests/optimizers/mod.rs
@@ -1,2 +1,3 @@
+mod adam;
 mod rmsprop;
 mod sgd;


### PR DESCRIPTION
Added `Adam` struct that implements the `Optimizer` trait, closely following its PyTorch implementation. It essentially combines the two types of momentums found in `SGD` and `RMSProp` (with respective decay rates β1 and β2) by keeping track of several gradient-based averages.

Source: https://pytorch.org/docs/stable/generated/torch.optim.Adam.html#torch.optim.Adam