### PR TITLE
CNN and Linear layer bug fixes

### DIFF
--- a/src/layers/linear.rs
+++ b/src/layers/linear.rs
@@ -5,16 +5,16 @@ use crate::prelude::*;
 use crate::utils::{GlorotUniform, WeightInit};
 
 pub struct Linear {
-    name: String,
-    weights: Tensor<Ix2>,
-    biases: Tensor<Ix1>,
+    pub name: String,
+    pub weights: Tensor<Ix2>,
+    pub biases: Tensor<Ix1>,
 }
 
 impl Linear {
     pub fn new(name: impl ToString, nin: usize, nout: usize) -> Self {
         let name = name.to_string();
         let weights =
-            Tensor::from_shape_simple_fn((nin, nout), || GlorotUniform.sample([nin, nout]));
+            Tensor::from_shape_simple_fn((nout, nin), || GlorotUniform.sample([nin, nout]));
         let biases = Tensor::from_shape_simple_fn(nout, Value::zero);
 
         Linear {
@@ -32,7 +32,7 @@ where
     Tensor<E>: Add<Tensor<Ix1>, Output = Tensor<D>>,
 {
     fn forward(&self, input: &Tensor<D>) -> Tensor<D> {
-        input.dot(&self.weights) + self.biases.clone()
+        input.dot(&self.weights.t().to_owned()) + self.biases.clone()
     }
 
     fn weights(&self) -> Tensor<Ix1> {

--- a/tests/layers/convolution.rs
+++ b/tests/layers/convolution.rs
@@ -29,7 +29,7 @@ fn conv_returns_valid_parameter_count() {
 
 #[test]
 fn valid_convolution() {
-    let mut conv2d = Conv2D::new(1, 1, 1, (2, 2), (0, 0), (1, 1), (1, 1));
+    let mut conv2d = Conv2D::new("conv2d", 1, 1, (2, 2), (0, 0), (1, 1), (1, 1));
     conv2d.weights =
         Array4::from_shape_vec((1, 1, 2, 2), values![0.3954, -0.1740, -0.1890, 0.4909]).unwrap();
     conv2d.biases = Tensor::from_vec(values!(-0.1188));
@@ -57,6 +57,50 @@ fn valid_convolution() {
         -0.60507223,
         0.38358044,
         -0.40010961,
+    ];
+
+    for (output, actual) in outputs.into_iter().zip(actuals) {
+        assert_abs_diff_eq!(output, actual, epsilon = 1e-6);
+    }
+}
+
+#[test]
+fn valid_two_channel_convolution() {
+    let mut conv2d = Conv2D::new("conv2d", 2, 3, (1, 1), (0, 0), (1, 1), (1, 1));
+    conv2d.weights = Array4::from_shape_vec(
+        (3, 2, 1, 1),
+        values![
+            -0.652845561504364,
+            0.6282326579093933,
+            0.29982179403305054,
+            0.03919875994324684,
+            0.6031246185302734,
+            -0.367204487323761
+        ],
+    )
+    .unwrap();
+    conv2d.biases = Tensor::from_vec(values![
+        0.6449103355407715,
+        -0.07897130399942398,
+        -0.5736885070800781
+    ]);
+
+    let input = Array4::from_shape_vec((1, 2, 2, 2), values![1, 2, 3, 4, 5, 6, 7, 8]).unwrap();
+
+    let outputs = conv2d.forward(&input).mapv(|v| v.value()).into_raw_vec();
+    let actuals = vec![
+        3.133228063583374,
+        3.1086151599884033,
+        3.0840022563934326,
+        3.059389352798462,
+        0.41684430837631226,
+        0.7558647990226746,
+        1.0948854684829712,
+        1.4339059591293335,
+        -1.8065862655639648,
+        -1.5706661939620972,
+        -1.3347461223602295,
+        -1.0988259315490723,
     ];
 
     for (output, actual) in outputs.into_iter().zip(actuals) {


### PR DESCRIPTION
Recently we have only experimented with the `Convolution` layer with a single in-channel, which is why we currently notice some discrepancies for this layer when compared to a Pytorch `Conv2D` with multiple channels. This PR fixes this bug and introduces a new test case to ensure it never resurfaces.

In addition, I also reverted to having Linear weights as `[nout, nin]` because it is how Pytorch stores its weight tensor.

These changes became necessary after working on implementing a pre-trained MNIST CNN model with our framework, PR for MNIST will be coming after this one!